### PR TITLE
Small changes to tangle explorer layout and font details

### DIFF
--- a/tangle-explorer-web/src/components/IotaBalanceView.vue
+++ b/tangle-explorer-web/src/components/IotaBalanceView.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <span class="iota-val">{{ convertToUnits(value) }}</span>
+  <span>{{ convertToUnits(value) }}</span>
 </template>
 
 <script>

--- a/tangle-explorer-web/src/components/SearchField.vue
+++ b/tangle-explorer-web/src/components/SearchField.vue
@@ -1,6 +1,6 @@
 <template lang="html">
   <div class='search'>
-    <input v-on:keyup.enter="pickFirstResult()" @input="update" v-model="searchText" type='text' placeholder="Search transactions, adresses" />
+    <input class="search-input" v-on:keyup.enter="pickFirstResult()" @input="update" v-model="searchText" type='text' placeholder="Search transactions, addresses" />
     <search-results :click='close' v-if="addrResults !== null || txResults !== null || bundleResults !== null" :bundleResults='bundleResults' :txResults='txResults' :addrResults='addrResults'></search-results>
   </div>
 </template>
@@ -89,4 +89,5 @@ export default {
   input
     border 1px solid #333
     padding 10px
+    width 400px
 </style>

--- a/tangle-explorer-web/src/components/SearchResults.vue
+++ b/tangle-explorer-web/src/components/SearchResults.vue
@@ -1,10 +1,10 @@
 <template lang="html">
   <div class='results' v-if="addrResults !== null || txResults !== null">
     <div class="result" @click="goTo('Transaction', result.hash)" v-for="result in txResults">
-      <div class="cut-text hash">{{ result.hash }}</div>
+      <div class="cut-text hash"><span class="result-cat">Hash: </span>{{ result.hash }}</div>
       <div class="cut-text address">
         <ceri-icon name="fa-user"></ceri-icon>
-        {{ result.address }}
+        <span class="result-cat">Address: </span> {{ result.address }}     
       </div>
       <div class="cut-text time">
         <ceri-icon name="fa-clock-o"></ceri-icon>
@@ -13,12 +13,12 @@
     </div>
 
     <div class="result" @click="goTo('Address', result.address)" v-for="result in addrResults">
-      <div class="cut-text hash">
+      <div class="cut-text address">
         <ceri-icon name="fa-user"></ceri-icon>
-        {{ result.address }}
+        <span class="result-cat">Address: </span>{{ result.address }}
       </div>
       <div class="cut-text balance">
-        <iota-balance-view :value='result.balance'></iota-balance-view>
+        <span class="result-cat">Balance: </span><iota-balance-view :value='result.balance'></iota-balance-view>
       </div>
     </div>
 
@@ -63,16 +63,20 @@ export default {
 <style lang="stylus" scoped>
 .results
   position absolute
-  left 1px
-  right 1px
+  left 0px
+  right 0px
   background #fff
+  border-left 1px solid #121728
+  border-right 1px solid #121728
+  border-bottom 1px solid #121728
 
   .result:hover
     background #eee
 
   .result
     padding 5px
+    padding-left 0px
     cursor pointer
-    .hash
+    .result-cat
       font-weight bold
 </style>

--- a/tangle-explorer-web/src/components/TXIo.vue
+++ b/tangle-explorer-web/src/components/TXIo.vue
@@ -79,6 +79,7 @@ export default {
     overflow hidden
     text-overflow ellipsis
     white-space: nowrap
+    line-height 28px
 
   .arrow
     float left

--- a/tangle-explorer-web/src/components/TopBar.vue
+++ b/tangle-explorer-web/src/components/TopBar.vue
@@ -28,6 +28,7 @@ export default {
 
 .logo {
   margin-top 5px
+  margin-left 5px
 }
 .search {
   margin-top 20px

--- a/tangle-explorer-web/src/pages/Address.vue
+++ b/tangle-explorer-web/src/pages/Address.vue
@@ -134,9 +134,14 @@ legend {
   .tx-info
     width auto
     padding 5px
+    padding-top 0px
+    padding-left 12px
     overflow:hidden
     .name
+    {
       font-weight bold
+      margin-bottom 2px
+    }
     .value
       word-break break-all
       font-size 15px
@@ -156,9 +161,11 @@ legend {
     .addr
       font-size 15px
       word-break break-all
+      margin-top 4px
 
   .title
     height 40px
+    margin-bottom 10px
 
     .tx-info-title, .addr-box-title
       font-weight bold

--- a/tangle-explorer-web/src/pages/Transaction.vue
+++ b/tangle-explorer-web/src/pages/Transaction.vue
@@ -64,7 +64,7 @@
     <tangle-graph :txs='[tx]' :viewingHash='tx.hash'></tangle-graph>
 
     <legend>
-      Transaction details
+      Transaction Details
     </legend>
     <table class="striped">
       <tbody>
@@ -216,6 +216,7 @@ export default {
     overflow hidden
     text-overflow ellipsis
     white-space: nowrap
+    line-height 28px
 
   .arrow
     float left
@@ -232,13 +233,19 @@ export default {
 
   .tx-info
     width auto
-    padding 10px
+    padding 5px
+    padding-top 0px
+    padding-left 12px
     overflow:hidden
     .name
+    {
       font-weight bold
+      margin-bottom 2px
+    }
     .value
       word-break break-all
-      font-size 15px
+      font-size 16px
+      letter-spacing 1px
 
   +mobile()
     .addr-box
@@ -254,10 +261,13 @@ export default {
       width 100%
     .addr
       font-size 15px
+      letter-spacing 1px     
       word-break break-all
+      margin-top 4px
 
   .title
     height 40px
+    margin-bottom 10px
 
     .tx-info-title, .addr-box-title
       font-weight bold

--- a/tangle-explorer-web/src/styles/layout.styl
+++ b/tangle-explorer-web/src/styles/layout.styl
@@ -93,18 +93,11 @@ a
   margin-bottom 2px
 }
 
-.balance
-{
+.balance, .hash{
   margin-left 5px
 }
 
-.hash
-{
-  margin-left 5px
-}
-
-.iota-val
-{
+.iota-val{
   font-weight 600
 }
 

--- a/tangle-explorer-web/src/styles/layout.styl
+++ b/tangle-explorer-web/src/styles/layout.styl
@@ -8,6 +8,9 @@
 
 .mono-space {
   font-family: "Courier New", Courier, monospace
+  letter-spacing 1px
+  line-height 18px
+  margin-bottom: 10px
 }
 
 legend {
@@ -72,6 +75,9 @@ a
     &.mobile
       display none
 
+  .search-input
+    width 200px!important
+
 * {
   box-sizing: border-box;
 }
@@ -84,8 +90,25 @@ a
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin-bottom 2px
+}
+
+.balance
+{
+  margin-left 5px
+}
+
+.hash
+{
+  margin-left 5px
+}
+
+.iota-val
+{
+  font-weight 600
 }
 
 .qr img {
   width 100%
 }
+


### PR DESCRIPTION
This merge relates to several small tweaks made to explorer relating to font size, spacing.
Changes include:
Adding default letter spacing for all transaction text
Search popup consistency changes to bolding and titles
Layout spacing for several header text blocks
Bolding of all transacted values
Fixing of several typos
