### PR TITLE
New graphical improvements

### DIFF
--- a/tangle-explorer-web/package.json
+++ b/tangle-explorer-web/package.json
@@ -23,6 +23,7 @@
     "stylus-loader": "^3.0.1",
     "vis": "^4.20.1",
     "vue": "^2.3.3",
+    "vue-easy-toast": "^1.0.2",
     "vue-router": "^2.6.0",
     "vue-spinner": "^1.0.2"
   },

--- a/tangle-explorer-web/src/components/TangleGraph.vue
+++ b/tangle-explorer-web/src/components/TangleGraph.vue
@@ -10,7 +10,7 @@
       <span class="txLabel" id="valueLabel">Value: {{this.txValue}}</span>          
       <span class="txLabel" id="tagLabel">Tag: {{this.txTag}}</span>    
       <div class="toolbar">
-        <div v-if="network !== null" class="button inceaseButton" @click="increaseDepth()">
+        <div :title='"Expand the graph to include transactions which directly reference the current transactions"' v-if="network !== null && this.networkLoading === false" class="button inceaseButton" @click="increaseDepth()">
           <ceri-icon class="increaseIcon" name="fa-plus-square"></ceri-icon><span>Increase Depth</span>
         </div>
         <div class='button' v-else>
@@ -177,6 +177,7 @@ export default {
       return new vis.DataSet(arr)
     },
     increaseDepth() {
+      this.networkLoading = true;      
       var arr = []
       for (var tx of this.txsToRender) {
         arr.push(tx.branchTransaction)
@@ -200,6 +201,7 @@ export default {
         _this.txsToRender = _.uniqBy(_this.txsToRender, (tx) => {
           return tx.hash
         })
+        _this.networkLoading = false;
         _this.update()
       })
     },
@@ -223,9 +225,9 @@ export default {
         this.txsToRender = this.txs.slice(0)
       }
       
-              var t = this.txsToRender.find(function(el){return (el.hash == this.viewingHash) ? el : null},this) 
-        this.txTag = (t) ? t.tag : "''"
-        this.txValue = (t) ? t.value : "0"
+      var t = this.txsToRender.find(function(el){return (el.hash == this.viewingHash) ? el : null},this) 
+      this.txTag = (t) ? t.tag : "''"
+      this.txValue = (t) ? t.value : "0"
       var container = this.$refs.graph
       var nodes = this.txsToNodes(this.txsToRender)
       var edges = this.txsToEdges(this.txsToRender)
@@ -300,7 +302,8 @@ export default {
       edgeCount: null,
       expanded: false,
       oldOffset: null,
-      shouldShowPusher: false
+      shouldShowPusher: false,
+      networkLoading: false
     }
   },
   mounted() {

--- a/tangle-explorer-web/src/directives/toast.js
+++ b/tangle-explorer-web/src/directives/toast.js
@@ -1,0 +1,17 @@
+import Vue from 'vue';
+Vue.directive('toast', {
+  bind: function (el, binding, vnode) {    
+    el.event = function(event)
+    {        
+        if(el == event.target || el.contains(event.target))
+        {
+            Vue.toast(binding.expression.replace(/"/g,''),{className:['toast-box'],verticalPosition: 'bottom', duration: 3000})
+        }
+    }
+    document.body.addEventListener('click', el.event)    
+  },
+  unbind: function (el) {
+    document.body.removeEventListener('click', el.event)
+  }
+})
+

--- a/tangle-explorer-web/src/main.js
+++ b/tangle-explorer-web/src/main.js
@@ -3,12 +3,15 @@
 import Vue from 'vue';
 import App from './App';
 import router from './router';
+import Toast from 'vue-easy-toast'
 
 const IOTAPlugin = require('@/utils/IOTAPlugin').default
 Vue.use(IOTAPlugin)
+Vue.use(Toast)
 
 // Directives (global)
 require('@/directives/click-outside.js')
+require('@/directives/toast.js')
 
 // Styles (global)
 require('@/styles/layout.styl')

--- a/tangle-explorer-web/src/pages/Settings.vue
+++ b/tangle-explorer-web/src/pages/Settings.vue
@@ -14,8 +14,8 @@
                 </tr>
             </tbody>
         </table>
-        <input title="Save these settings" type="submit" class="primary btn" value="Apply" />
-        <input title="Reset all settings to the default values" type="button" @click="reset()" class="destructive btn" value="Reset" />
+        <input title="Save these settings" type="submit" class="primary btn" value="Apply" v-toast='"Settings Saved"' />
+        <input title="Reset all settings to the default values" type="button" @click="reset()" class="destructive btn" value="Reset" v-toast='"Settings Reset"'  />
       </form>
     </div>
   </div>

--- a/tangle-explorer-web/src/pages/Transaction.vue
+++ b/tangle-explorer-web/src/pages/Transaction.vue
@@ -59,11 +59,6 @@
       No Tx I/O found :(
     </div>
     <legend>
-      Position in Tangle
-    </legend>
-    <tangle-graph :txs='[tx]' :viewingHash='tx.hash'></tangle-graph>
-
-    <legend>
       Transaction Details
     </legend>
     <table class="striped">
@@ -124,7 +119,12 @@
           </tr>
       </tbody>
     </table>
+    <legend>
+      Position in Tangle
+    </legend>
+    <tangle-graph :txs='[tx]' :viewingHash='tx.hash' :viewingTrunkHash='tx.trunkTransaction' :viewingBranchHash='tx.branchTransaction'></tangle-graph>
   </div>
+  
   <div class="page-loading" v-else>
     <pulse-loader :color="'#000'" size='30px'></pulse-loader>
   </div>
@@ -220,7 +220,7 @@ export default {
 
   .arrow
     position absolute
-    left: 0; 
+    left: 0;
     right: 0; 
     margin-left: auto; 
     margin-right: auto; 

--- a/tangle-explorer-web/src/styles/layout.styl
+++ b/tangle-explorer-web/src/styles/layout.styl
@@ -111,3 +111,11 @@ a
 .qr img {
   width 100%
 }
+
+.toast-box
+{
+  color:#fff
+  font-family: 'arial'
+  border-radius: 0px
+  margin 10px
+}


### PR DESCRIPTION
I've added toast popup functionality for the settings screen. This could potentially extend to other part of the site, as simple as using the custom toast directive on any element you want toasted.
Also made some provisional changes to the tangle explorer graph. I've simplified the colour scheme somewhat, and added several pieces of interesting information to the canvas pertaining to the graph, and selected transaction. Future versions of this could use popups on hover, with clickable links.
Finally, updated the loading indicator on the increase depth button to display when the iota library is performing its search. Useful for slower pcs.